### PR TITLE
fix: fix a problem with Kotlin type inference and the serialization of the Any type

### DIFF
--- a/core/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/core/Behaviour.kt
+++ b/core/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/core/Behaviour.kt
@@ -8,7 +8,7 @@ package it.nicolasfarabegoli.pulverization.core
  * @param A the type of the actuations
  * @param O the type of the outcome of the function
  */
-data class BehaviourOutput<S : StateRepresentation, E : CommunicationPayload, A, O>(
+data class BehaviourOutput<S : Any, E : Any, A : Any, O : Any>(
     val newState: S,
     val newExport: E,
     val actuations: A,
@@ -23,7 +23,7 @@ data class BehaviourOutput<S : StateRepresentation, E : CommunicationPayload, A,
  * @param W the type of the sensed values
  * @param A the type of the actuation to do
  */
-interface Behaviour<S, E, W, A, O> : PulverizedComponent where S : StateRepresentation, E : CommunicationPayload {
+interface Behaviour<S : Any, E : Any, W : Any, A : Any, O : Any> : PulverizedComponent {
     override val componentType: PulverizedComponentType
         get() = BehaviourComponent
 

--- a/core/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/core/Communication.kt
+++ b/core/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/core/Communication.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 /**
  * Marker interface modelling the export payload.
  */
-interface CommunicationPayload
+// interface CommunicationPayload
 
 /**
  * This interface model the _Communication component_ in a pulverized context.
@@ -13,7 +13,7 @@ interface CommunicationPayload
  * @param S the type of the message to send.
  * @param R the type of the message to receive.
  */
-interface Communication<P : CommunicationPayload> : PulverizedComponent {
+interface Communication<P : Any> : PulverizedComponent {
     override val componentType: PulverizedComponentType
         get() = CommunicationComponent
 

--- a/core/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/core/State.kt
+++ b/core/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/core/State.kt
@@ -4,13 +4,13 @@ package it.nicolasfarabegoli.pulverization.core
  * Marker interface modelling the representation of the [State].
  * Each state representation must implement this interface.
  */
-interface StateRepresentation
+// interface StateRepresentation
 
 /**
  * Models the concept of [State] in the pulverization context.
  * @param S the type of the [State].
  */
-interface State<S : StateRepresentation> : PulverizedComponent {
+interface State<S : Any> : PulverizedComponent {
     override val componentType: PulverizedComponentType
         get() = StateComponent
 

--- a/examples/example-03/src/commonMain/kotlin/example/components/BehaviourComp.kt
+++ b/examples/example-03/src/commonMain/kotlin/example/components/BehaviourComp.kt
@@ -7,7 +7,6 @@ import it.nicolasfarabegoli.pulverization.runtime.componentsref.ActuatorsRef
 import it.nicolasfarabegoli.pulverization.runtime.componentsref.CommunicationRef
 import it.nicolasfarabegoli.pulverization.runtime.componentsref.SensorsRef
 import it.nicolasfarabegoli.pulverization.runtime.componentsref.StateRef
-import it.nicolasfarabegoli.pulverization.runtime.dsl.NoVal
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -18,7 +17,7 @@ import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
 
-class BehaviourComp : Behaviour<StateOps, NeighboursMessage, DeviceSensors, NoVal, Unit> {
+class BehaviourComp : Behaviour<StateOps, NeighboursMessage, DeviceSensors, Any, Unit> {
     override val context: Context by inject()
 
     companion object {
@@ -30,7 +29,7 @@ class BehaviourComp : Behaviour<StateOps, NeighboursMessage, DeviceSensors, NoVa
         state: StateOps,
         export: List<NeighboursMessage>,
         sensedValues: DeviceSensors,
-    ): BehaviourOutput<StateOps, NeighboursMessage, NoVal, Unit> {
+    ): BehaviourOutput<StateOps, NeighboursMessage, Any, Unit> {
         val (myLat, myLong) = sensedValues.gps
         val distances = export.map { (device, location) ->
             val dLat = (location.lat - myLat) * PI / ANGLE
@@ -46,7 +45,7 @@ class BehaviourComp : Behaviour<StateOps, NeighboursMessage, DeviceSensors, NoVa
         return BehaviourOutput(
             Distances(distances, min),
             NeighboursMessage(context.deviceID, sensedValues.gps),
-            NoVal,
+            Unit,
             Unit,
         )
     }
@@ -54,11 +53,11 @@ class BehaviourComp : Behaviour<StateOps, NeighboursMessage, DeviceSensors, NoVa
 
 @Suppress("UNUSED_PARAMETER")
 suspend fun behaviourLogics(
-    behaviour: Behaviour<StateOps, NeighboursMessage, DeviceSensors, NoVal, Unit>,
+    behaviour: Behaviour<StateOps, NeighboursMessage, DeviceSensors, Any, Unit>,
     state: StateRef<StateOps>,
     comm: CommunicationRef<NeighboursMessage>,
     sensors: SensorsRef<DeviceSensors>,
-    actuators: ActuatorsRef<NoVal>,
+    actuators: ActuatorsRef<Any>,
 ) = coroutineScope {
     var neighboursComm = listOf<NeighboursMessage>()
     val jobComm = launch {

--- a/examples/example-03/src/commonMain/kotlin/example/components/CommunicationComp.kt
+++ b/examples/example-03/src/commonMain/kotlin/example/components/CommunicationComp.kt
@@ -1,14 +1,13 @@
 package example.components
 
 import it.nicolasfarabegoli.pulverization.core.Communication
-import it.nicolasfarabegoli.pulverization.core.CommunicationPayload
 import it.nicolasfarabegoli.pulverization.runtime.componentsref.BehaviourRef
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class NeighboursMessage(val device: String, val location: Gps) : CommunicationPayload
+data class NeighboursMessage(val device: String, val location: Gps)
 
 expect class CommunicationComp : Communication<NeighboursMessage>
 

--- a/examples/example-03/src/commonMain/kotlin/example/components/StateComp.kt
+++ b/examples/example-03/src/commonMain/kotlin/example/components/StateComp.kt
@@ -2,13 +2,12 @@ package example.components
 
 import it.nicolasfarabegoli.pulverization.component.Context
 import it.nicolasfarabegoli.pulverization.core.State
-import it.nicolasfarabegoli.pulverization.core.StateRepresentation
 import it.nicolasfarabegoli.pulverization.runtime.componentsref.BehaviourRef
 import kotlinx.serialization.Serializable
 import org.koin.core.component.inject
 
 @Serializable
-sealed interface StateOps : StateRepresentation
+sealed interface StateOps
 
 @Serializable
 data class Distances(val distances: List<Pair<String, Double>>, val nearest: Pair<String, Double>?) : StateOps

--- a/examples/example-03/src/jvmMain/kotlin/example/units/BehaviourUnit.kt
+++ b/examples/example-03/src/jvmMain/kotlin/example/units/BehaviourUnit.kt
@@ -5,7 +5,6 @@ import example.components.behaviourLogics
 import it.nicolasfarabegoli.pulverization.dsl.getDeviceConfiguration
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.RabbitmqCommunicator
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.defaultRabbitMQRemotePlace
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.behaviourLogic
 import it.nicolasfarabegoli.pulverization.runtime.dsl.pulverizationPlatform
 import kotlinx.coroutines.runBlocking
 

--- a/examples/example-03/src/jvmMain/kotlin/example/units/CommunicationUnit.kt
+++ b/examples/example-03/src/jvmMain/kotlin/example/units/CommunicationUnit.kt
@@ -1,20 +1,21 @@
 package example.units
 
 import example.components.CommunicationComp
+import example.components.NeighboursMessage
 import example.components.communicationLogic
 import it.nicolasfarabegoli.pulverization.dsl.getDeviceConfiguration
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.RabbitmqCommunicator
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.defaultRabbitMQRemotePlace
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.communicationLogic
 import it.nicolasfarabegoli.pulverization.runtime.dsl.pulverizationPlatform
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val platform = pulverizationPlatform(config.getDeviceConfiguration("gps")!!) {
-        communicationLogic(CommunicationComp(), ::communicationLogic)
-        withPlatform { RabbitmqCommunicator(hostname = "rabbitmq") }
-        withRemotePlace { defaultRabbitMQRemotePlace() }
-    }
+    val platform =
+        pulverizationPlatform<Any, NeighboursMessage, Any, Any, Unit>(config.getDeviceConfiguration("gps")!!) {
+            communicationLogic(CommunicationComp(), ::communicationLogic)
+            withPlatform { RabbitmqCommunicator(hostname = "rabbitmq") }
+            withRemotePlace { defaultRabbitMQRemotePlace() }
+        }
     val jobs = platform.start()
     jobs.forEach { it.join() }
     platform.stop()

--- a/examples/example-03/src/jvmMain/kotlin/example/units/SensorsUnit.kt
+++ b/examples/example-03/src/jvmMain/kotlin/example/units/SensorsUnit.kt
@@ -1,11 +1,11 @@
 package example.units
 
+import example.components.DeviceSensors
 import example.components.LocalizationSensor
 import example.components.mySensorsLogic
 import it.nicolasfarabegoli.pulverization.dsl.getDeviceConfiguration
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.RabbitmqCommunicator
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.defaultRabbitMQRemotePlace
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.sensorsLogic
 import it.nicolasfarabegoli.pulverization.runtime.dsl.pulverizationPlatform
 import kotlinx.coroutines.runBlocking
 
@@ -13,7 +13,7 @@ import kotlinx.coroutines.runBlocking
  * State-Behaviour entrypoint.
  */
 fun main() = runBlocking {
-    val platform = pulverizationPlatform(config.getDeviceConfiguration("gps")!!) {
+    val platform = pulverizationPlatform<Any, Any, DeviceSensors, Any, Unit>(config.getDeviceConfiguration("gps")!!) {
         sensorsLogic(LocalizationSensor(), ::mySensorsLogic)
         withPlatform { RabbitmqCommunicator(hostname = "rabbitmq") }
         withRemotePlace { defaultRabbitMQRemotePlace() }

--- a/examples/example-03/src/jvmMain/kotlin/example/units/StateUnit.kt
+++ b/examples/example-03/src/jvmMain/kotlin/example/units/StateUnit.kt
@@ -1,16 +1,16 @@
 package example.units
 
 import example.components.StateComp
+import example.components.StateOps
 import example.components.stateLogic
 import it.nicolasfarabegoli.pulverization.dsl.getDeviceConfiguration
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.RabbitmqCommunicator
 import it.nicolasfarabegoli.pulverization.platforms.rabbitmq.defaultRabbitMQRemotePlace
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.stateLogic
 import it.nicolasfarabegoli.pulverization.runtime.dsl.pulverizationPlatform
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
-    val platform = pulverizationPlatform(config.getDeviceConfiguration("gps")!!) {
+    val platform = pulverizationPlatform<StateOps, Any, Any, Any, Unit>(config.getDeviceConfiguration("gps")!!) {
         stateLogic(StateComp(), ::stateLogic)
         withPlatform { RabbitmqCommunicator(hostname = "rabbitmq") }
         withRemotePlace { defaultRabbitMQRemotePlace() }

--- a/platform/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/runtime/componentsref/CommunicationRef.kt
+++ b/platform/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/runtime/componentsref/CommunicationRef.kt
@@ -2,7 +2,6 @@ package it.nicolasfarabegoli.pulverization.runtime.componentsref
 
 import it.nicolasfarabegoli.pulverization.core.BehaviourComponent
 import it.nicolasfarabegoli.pulverization.core.CommunicationComponent
-import it.nicolasfarabegoli.pulverization.core.CommunicationPayload
 import it.nicolasfarabegoli.pulverization.runtime.communication.Communicator
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
@@ -10,34 +9,34 @@ import kotlinx.serialization.serializer
 /**
  * Represent a reference to the _communication_ component in a pulverized system.
  */
-interface CommunicationRef<S : CommunicationPayload> : ComponentRef<S> {
+interface CommunicationRef<S : Any> : ComponentRef<S> {
     companion object {
         /**
          * Create a [CommunicationRef] specifying the [serializer] and the [communicator] to be used.
          */
-        fun <S : CommunicationPayload> create(serializer: KSerializer<S>, communicator: Communicator):
+        fun <S : Any> create(serializer: KSerializer<S>, communicator: Communicator):
             CommunicationRef<S> = CommunicationRefImpl(serializer, communicator)
 
         /**
          * Create a [CommunicationRef] specifying the [communicator] to be used.
          */
-        inline fun <reified S : CommunicationPayload> create(communicator: Communicator): CommunicationRef<S> =
+        inline fun <reified S : Any> create(communicator: Communicator): CommunicationRef<S> =
             create(serializer(), communicator)
 
         /**
          * Create a fake component reference.
          * All the methods implementation with this instance do nothing.
          */
-        fun <S : CommunicationPayload> createDummy(): CommunicationRef<S> = NoOpCommunicationRef()
+        fun <S : Any> createDummy(): CommunicationRef<S> = NoOpCommunicationRef()
     }
 }
 
-internal class CommunicationRefImpl<S : CommunicationPayload>(
+internal class CommunicationRefImpl<S : Any>(
     private val serializer: KSerializer<S>,
     private val communicator: Communicator,
 ) : ComponentRef<S> by ComponentRefImpl(serializer, BehaviourComponent to CommunicationComponent, communicator),
     CommunicationRef<S>
 
-internal class NoOpCommunicationRef<S : CommunicationPayload> :
+internal class NoOpCommunicationRef<S : Any> :
     ComponentRef<S> by NoOpComponentRef(),
     CommunicationRef<S>

--- a/platform/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/runtime/componentsref/ComponentsRefManager.kt
+++ b/platform/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/runtime/componentsref/ComponentsRefManager.kt
@@ -3,17 +3,15 @@ package it.nicolasfarabegoli.pulverization.runtime.componentsref
 import it.nicolasfarabegoli.pulverization.core.ActuatorsComponent
 import it.nicolasfarabegoli.pulverization.core.BehaviourComponent
 import it.nicolasfarabegoli.pulverization.core.CommunicationComponent
-import it.nicolasfarabegoli.pulverization.core.CommunicationPayload
 import it.nicolasfarabegoli.pulverization.core.PulverizedComponentType
 import it.nicolasfarabegoli.pulverization.core.SensorsComponent
 import it.nicolasfarabegoli.pulverization.core.StateComponent
-import it.nicolasfarabegoli.pulverization.core.StateRepresentation
 import it.nicolasfarabegoli.pulverization.runtime.communication.Communicator
 import it.nicolasfarabegoli.pulverization.runtime.communication.LocalCommunicator
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
 
-internal fun <S : StateRepresentation> createStateRef(
+internal fun <S : Any> createStateRef(
     serializer: KSerializer<S>,
     allComponents: Set<PulverizedComponentType>,
     deploymentUnit: Set<PulverizedComponentType>,
@@ -27,7 +25,7 @@ internal fun <S : StateRepresentation> createStateRef(
     }
 }
 
-internal fun <C : CommunicationPayload> createCommunicationRef(
+internal fun <C : Any> createCommunicationRef(
     serializer: KSerializer<C>,
     allComponents: Set<PulverizedComponentType>,
     deploymentUnit: Set<PulverizedComponentType>,
@@ -98,12 +96,12 @@ internal fun <S : Any> setupBehaviourRef(
     }
 }
 
-internal data class ComponentsRefInstances<S, C, SS, AS>(
+internal data class ComponentsRefInstances<S : Any, C : Any, SS : Any, AS : Any>(
     val stateRef: StateRef<S>,
     val communicationRef: CommunicationRef<C>,
     val sensorsRef: SensorsRef<SS>,
     val actuatorsRef: ActuatorsRef<AS>,
-) where S : StateRepresentation, C : CommunicationPayload, SS : Any, AS : Any
+)
 
 internal sealed interface Placement
 internal object Remote : Placement

--- a/platform/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/runtime/componentsref/StateRef.kt
+++ b/platform/src/commonMain/kotlin/it/nicolasfarabegoli/pulverization/runtime/componentsref/StateRef.kt
@@ -2,7 +2,6 @@ package it.nicolasfarabegoli.pulverization.runtime.componentsref
 
 import it.nicolasfarabegoli.pulverization.core.BehaviourComponent
 import it.nicolasfarabegoli.pulverization.core.StateComponent
-import it.nicolasfarabegoli.pulverization.core.StateRepresentation
 import it.nicolasfarabegoli.pulverization.runtime.communication.Communicator
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.serializer
@@ -10,32 +9,32 @@ import kotlinx.serialization.serializer
 /**
  * Represent a reference to the _state_ component in a pulverized system.
  */
-interface StateRef<S : StateRepresentation> : ComponentRef<S> {
+interface StateRef<S : Any> : ComponentRef<S> {
     companion object {
         /**
          * Create a [StateRef] specifying the [serializer] and the [communicator] to be used.
          */
-        fun <S : StateRepresentation> create(serializer: KSerializer<S>, communicator: Communicator): StateRef<S> =
+        fun <S : Any> create(serializer: KSerializer<S>, communicator: Communicator): StateRef<S> =
             StateRefImpl(serializer, communicator)
 
         /**
          * Create a [StateRef] specifying the [communicator] to be used.
          */
-        inline fun <reified S : StateRepresentation> create(communicator: Communicator): StateRef<S> =
+        inline fun <reified S : Any> create(communicator: Communicator): StateRef<S> =
             create(serializer(), communicator)
 
         /**
          * Create a fake component reference.
          * All the methods implementation with this instance do nothing.
          */
-        fun <S : StateRepresentation> createDummy(): StateRef<S> = NoOpStateRef()
+        fun <S : Any> createDummy(): StateRef<S> = NoOpStateRef()
     }
 }
 
-internal data class StateRefImpl<S : StateRepresentation>(
+internal data class StateRefImpl<S : Any>(
     private val serializer: KSerializer<S>,
     private val communicator: Communicator,
 ) : ComponentRef<S> by ComponentRefImpl(serializer, BehaviourComponent to StateComponent, communicator),
     StateRef<S>
 
-internal class NoOpStateRef<S : StateRepresentation> : ComponentRef<S> by NoOpComponentRef(), StateRef<S>
+internal class NoOpStateRef<S : Any> : ComponentRef<S> by NoOpComponentRef(), StateRef<S>

--- a/platform/src/commonTest/kotlin/it/nicolasfarabegoli/pulverization/runtime/AsyncScenario.kt
+++ b/platform/src/commonTest/kotlin/it/nicolasfarabegoli/pulverization/runtime/AsyncScenario.kt
@@ -11,10 +11,6 @@ import it.nicolasfarabegoli.pulverization.dsl.pulverizationConfig
 import it.nicolasfarabegoli.pulverization.runtime.dsl.CommPayload
 import it.nicolasfarabegoli.pulverization.runtime.dsl.CommunicationFixture
 import it.nicolasfarabegoli.pulverization.runtime.dsl.FixtureBehaviour
-import it.nicolasfarabegoli.pulverization.runtime.dsl.NoVal
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.behaviourLogic
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.communicationLogic
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.stateLogic
 import it.nicolasfarabegoli.pulverization.runtime.dsl.StateFixture
 import it.nicolasfarabegoli.pulverization.runtime.dsl.StatePayload
 import it.nicolasfarabegoli.pulverization.runtime.dsl.pulverizationPlatform
@@ -41,7 +37,7 @@ class AsyncScenario : FreeSpec(
                         val comm: CommPayload = commDefer.await()
                         st shouldBe StatePayload(0)
                         comm shouldBe CommPayload(3)
-                        val r = b(st, listOf(comm), NoVal)
+                        val r = b(st, listOf(comm), 1)
                         sr.sendToComponent(r.newState)
                         cr.sendToComponent(r.newExport)
                     }

--- a/platform/src/commonTest/kotlin/it/nicolasfarabegoli/pulverization/runtime/dsl/ComponentsFixtures.kt
+++ b/platform/src/commonTest/kotlin/it/nicolasfarabegoli/pulverization/runtime/dsl/ComponentsFixtures.kt
@@ -1,12 +1,14 @@
 package it.nicolasfarabegoli.pulverization.runtime.dsl
 
 import it.nicolasfarabegoli.pulverization.component.Context
+import it.nicolasfarabegoli.pulverization.core.Actuator
+import it.nicolasfarabegoli.pulverization.core.ActuatorsContainer
 import it.nicolasfarabegoli.pulverization.core.Behaviour
 import it.nicolasfarabegoli.pulverization.core.BehaviourOutput
 import it.nicolasfarabegoli.pulverization.core.Communication
-import it.nicolasfarabegoli.pulverization.core.CommunicationPayload
+import it.nicolasfarabegoli.pulverization.core.Sensor
+import it.nicolasfarabegoli.pulverization.core.SensorsContainer
 import it.nicolasfarabegoli.pulverization.core.State
-import it.nicolasfarabegoli.pulverization.core.StateRepresentation
 import it.nicolasfarabegoli.pulverization.runtime.communication.Binding
 import it.nicolasfarabegoli.pulverization.runtime.communication.Communicator
 import it.nicolasfarabegoli.pulverization.runtime.communication.RemotePlace
@@ -17,21 +19,21 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class StatePayload(val i: Int) : StateRepresentation
+data class StatePayload(val i: Int)
 
 @Serializable
-data class CommPayload(val i: Int) : CommunicationPayload
+data class CommPayload(val i: Int)
 
-class FixtureBehaviour : Behaviour<StatePayload, CommPayload, NoVal, NoVal, Unit> {
+class FixtureBehaviour : Behaviour<StatePayload, CommPayload, Int, Double, Unit> {
     override val context: Context
         get() = TODO("Not yet implemented")
 
     override fun invoke(
         state: StatePayload,
         export: List<CommPayload>,
-        sensedValues: NoVal,
-    ): BehaviourOutput<StatePayload, CommPayload, NoVal, Unit> =
-        BehaviourOutput(state, CommPayload(2), NoVal, Unit)
+        sensedValues: Int,
+    ): BehaviourOutput<StatePayload, CommPayload, Double, Unit> =
+        BehaviourOutput(state, CommPayload(2), 1.0, Unit)
 }
 
 class StateFixture : State<StatePayload> {
@@ -53,6 +55,38 @@ class CommunicationFixture : Communication<CommPayload> {
 
     override suspend fun send(payload: CommPayload) {}
     override fun receive(): Flow<CommPayload> = emptyFlow()
+}
+
+class DeviceActuator : Actuator<Double> {
+    override suspend fun actuate(payload: Double) {
+        TODO("Not yet implemented")
+    }
+}
+
+class DeviceActuatorContainer : ActuatorsContainer() {
+    override val context: Context
+        get() = TODO("Not yet implemented")
+
+    override suspend fun initialize() {
+        val actuator = DeviceActuator().apply { initialize() }
+        this += actuator
+    }
+}
+
+class DeviceSensor : Sensor<Int> {
+    override suspend fun sense(): Int {
+        TODO("Not yet implemented")
+    }
+}
+
+class DeviceSensorContainer : SensorsContainer() {
+    override val context: Context
+        get() = TODO("Not yet implemented")
+
+    override suspend fun initialize() {
+        val sensor = DeviceSensor().apply { initialize() }
+        this += sensor
+    }
 }
 
 class RemoteCommunicator(private val comm: MutableSharedFlow<ByteArray>) : Communicator {

--- a/platform/src/commonTest/kotlin/it/nicolasfarabegoli/pulverization/runtime/dsl/PulverizationRuntimeTest.kt
+++ b/platform/src/commonTest/kotlin/it/nicolasfarabegoli/pulverization/runtime/dsl/PulverizationRuntimeTest.kt
@@ -11,9 +11,7 @@ import it.nicolasfarabegoli.pulverization.dsl.Cloud
 import it.nicolasfarabegoli.pulverization.dsl.Edge
 import it.nicolasfarabegoli.pulverization.dsl.getDeviceConfiguration
 import it.nicolasfarabegoli.pulverization.dsl.pulverizationConfig
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.behaviourLogic
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.communicationLogic
-import it.nicolasfarabegoli.pulverization.runtime.dsl.PulverizationPlatformScope.Companion.stateLogic
+import it.nicolasfarabegoli.pulverization.runtime.componentsref.BehaviourRef
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableSharedFlow
 import org.koin.core.context.stopKoin
@@ -24,6 +22,22 @@ class PulverizationRuntimeTest : FreeSpec(
             logicalDevice("device-1") {
                 BehaviourComponent and StateComponent deployableOn Edge
                 CommunicationComponent deployableOn Cloud
+            }
+        }
+        "The kotlin type inference" - {
+            "should infer the right type using only sensors and actuators" {
+                pulverizationPlatform<Any, Any, Int, Double, Unit>(config.getDeviceConfiguration("device-1")!!) {
+                    actuatorsLogic(DeviceActuatorContainer()) { _, _: BehaviourRef<Double> -> }
+                    sensorsLogic(DeviceSensorContainer()) { _, _: BehaviourRef<Int> -> }
+                }
+            }
+            "should compile mixing sensors and actuators with other component" {
+                pulverizationPlatform(config.getDeviceConfiguration("device-1")!!) {
+                    behaviourLogic(FixtureBehaviour()) { _, _, _, _, _ -> }
+                    communicationLogic(CommunicationFixture()) { _, _ -> }
+                    sensorsLogic(DeviceSensorContainer()) { _, _ -> }
+                    actuatorsLogic(DeviceActuatorContainer()) { _, _ -> }
+                }
             }
         }
         "The platform DSL" - {


### PR DESCRIPTION
This PR fixed a problem related to the machinery created in order to let Kotlin infer a default type when the platform doesn't use a specific type like `State` or `Communication`.

```kotlin
val platform = pulverizationPlatform(config) {
  sensorsLogic(DeviceSensors(), ::deviceSensorLogic)
  actuatorsLogic(DeviceActuators(), ::deviceActuatorLogic)
  // Other configs
}
```

The code above fails to compile due to the extensions method that lets Kotlin infer the suitable types. This approach fixes the default type on the first method call and, in this example, the `actuatorsLogic` could not be invoked.

This PR relaxes the automatic inference machinery, forcing the user to specify the default type (likely `Any` because `Nothing` can't be inlined) and resolve the issue where the `Any` type cannot be serialized; but since the default type is not used by the platform, give `Any` as default type is safe.

With this PR the code above should be changed as:

```kotlin
val platform = pulverizationPlatform<Any, Any, Int, Double, Unit>(config) {
  sensorsLogic(DeviceSensors(), ::deviceSensorLogic)
  actuatorsLogic(DeviceActuators(), ::deviceActuatorLogic)
  // Other configs
}
```